### PR TITLE
fix: remove unused github token reference

### DIFF
--- a/projects/bjerk-conf/index.ts
+++ b/projects/bjerk-conf/index.ts
@@ -1,8 +1,6 @@
 import * as pulumi from '@pulumi/pulumi';
-import { github } from './resources/config';
 import { serviceAccount } from './resources/google/service-account';
 import './resources/github/secrets';
 import './resources/google/api-services';
 
 export const serviceAccountEmail = pulumi.secret(serviceAccount.email);
-export const gitHubToken = pulumi.secret(github.token);


### PR DESCRIPTION
unused export from a dead import