### PR TITLE
feat: add cloud run viewer role to developers on timely

### DIFF
--- a/projects/core-infra/src/internal/timely-agent.ts
+++ b/projects/core-infra/src/internal/timely-agent.ts
@@ -27,15 +27,23 @@ new ProjectSlackLogger(
   { provider: setup.googleProvider },
 );
 
-developers.map(
-  developer =>
-    new gcp.projects.IAMMember(
-      `timely-agent-${developer}-private-logs-viewer`,
-      {
-        member: developer,
-        role: 'roles/logging.privateLogViewer',
-        project: setup.project.projectId,
-      },
-      { provider: setup.googleProvider },
-    ),
-);
+developers.map(developer => {
+  new gcp.projects.IAMMember(
+    `timely-agent-${developer}-private-logs-viewer`,
+    {
+      member: developer,
+      role: 'roles/logging.privateLogViewer',
+      project: setup.project.projectId,
+    },
+    { provider: setup.googleProvider },
+  );
+  new gcp.projects.IAMMember(
+    `timely-agent-${developer}-cloud-run-viewer`,
+    {
+      member: developer,
+      role: 'roles/run.viewer',
+      project: setup.project.projectId,
+    },
+    { provider: setup.googleProvider },
+  );
+});


### PR DESCRIPTION
I wanna see the address the service is running at!