### PR TITLE
fix: remove unused DNS records

### DIFF
--- a/projects/bjerk-io/src/zones/bjerk-io.ts
+++ b/projects/bjerk-io/src/zones/bjerk-io.ts
@@ -119,18 +119,6 @@ new gcp.dns.RecordSet(
 );
 
 new gcp.dns.RecordSet(
-  'bjerk-io-vault',
-  {
-    managedZone,
-    name: 'vault.bjerk.io.',
-    rrdatas: ['34.88.68.230'],
-    ttl,
-    type: 'A',
-  },
-  opts,
-);
-
-new gcp.dns.RecordSet(
   'bjerk-io-studio',
   {
     managedZone,

--- a/projects/bjerk-io/src/zones/bjerk-io.ts
+++ b/projects/bjerk-io/src/zones/bjerk-io.ts
@@ -131,18 +131,6 @@ new gcp.dns.RecordSet(
 );
 
 new gcp.dns.RecordSet(
-  'bjerk-io-reporting',
-  {
-    managedZone,
-    name: 'reporting.bjerk.io.',
-    rrdatas: ['34.88.68.230'],
-    ttl,
-    type: 'A',
-  },
-  opts,
-);
-
-new gcp.dns.RecordSet(
   'bjerk-io-studio',
   {
     managedZone,
@@ -165,4 +153,3 @@ new gcp.dns.RecordSet(
   },
   opts,
 );
-


### PR DESCRIPTION
These DNS records point to the old kubernetes cluster